### PR TITLE
Small UI fixes

### DIFF
--- a/client/app/history/history.html
+++ b/client/app/history/history.html
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <h1>Device history</h1>
+      <h1 class="page-header">Device history</h1>
       <table class="table">
         <thead>
         <tr><th>Device Label</th><th>Device Name</th><th>Lender</th><th>started</th><th>ended</th></tr>

--- a/client/app/main/main.html
+++ b/client/app/main/main.html
@@ -4,7 +4,7 @@
   <div class="row">
     <div class="col-lg-12">
       <alert ng-repeat="alert in alerts" type="{{alert.type}}" close="closeAlert($index)">{{alert.msg}}</alert>
-      <h1 class="page-header">Devices:</h1>
+      <h1 class="page-header">Devices</h1>
       <table class="table">
         <thead>
         <tr><th>Label</th><th>Name</th><th>Serial number</th><th>Attached</th></tr>

--- a/client/app/users/users.html
+++ b/client/app/users/users.html
@@ -10,7 +10,7 @@
         </thead>
         <tbody ng-repeat="user in users | orderBy:'name':0">
           <tr>
-            <td><a ng-href="/user/{{user._id}}">{{user.name}}</a><a class="remove-user-link" ng-click="removeUser(user)"><span class="glyphicon glyphicon-remove"></span></a></td>
+            <td><a ng-href="/user/{{user._id}}"><img class="gravatar-icon-small" src="{{user.gravatar_img}}">{{user.name}}</a><a class="remove-user-link" ng-click="removeUser(user)"><span class="glyphicon glyphicon-remove"></span></a></td>
           </tr>
         </tbody>
       </table>

--- a/client/app/users/users.scss
+++ b/client/app/users/users.scss
@@ -2,6 +2,11 @@
 	float: right;
 }
 
+.gravatar-icon-small {
+  max-height: 1.6em;
+  margin-right: 0.6em;
+}
+
 .remove-user-link {
 	cursor: pointer;
 	float: right;


### PR DESCRIPTION
Removed semicolon from “Devices:” H1 heading for consistency across
pages; added page-header class to history page’s H1 to provide
consistent top CSS padding.
